### PR TITLE
Correct release workflow (again)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,23 +13,25 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Get current version
         id: version
         run: |
           VERSION="v$(grep -oP 'version = "\K[0-9]+\.[0-9]+\.[0-9]+' Project.toml)"
           echo "Current version: $VERSION"
-          echo "::set-output name=version::$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Get previous version (last tag)
         id: prev_version
         run: |
           PREV_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
           echo "Previous version: $PREV_VERSION"
-          echo "::set-output name=prev_version::$PREV_VERSION"
+          echo "prev_version=$PREV_VERSION" >> $GITHUB_OUTPUT
 
       - name: Compare versions
         id: version_check
+        continue-on-error: true
         run: |
           CURRENT_VERSION=${{ steps.version.outputs.version }}
           PREV_VERSION=${{ steps.prev_version.outputs.prev_version }}


### PR DESCRIPTION
Set [`set-depth`](https://github.com/actions/checkout?tab=readme-ov-file) appropriately so it can actually discover the tags it's supposed to check and also correct the [depreacted `set-output` method](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) of writing values into the workflow state.